### PR TITLE
fix #7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "pingpp-html5",
+  "version": "2.0.6",
+  "homepage": "https://github.com/PingPlusPlus/pingpp-html5",
+  "authors": [
+    "https://github.com/PingPlusPlus"
+  ],
+  "main": "src/pingpp_pay.js",
+  "keywords": [
+    "pingpp",
+    "pingplusplus",
+    "pingxx"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "*.md",
+    "example-wap",
+    "example-webview"
+  ]
+}


### PR DESCRIPTION
添加 `bower` 支持。已注册：

``` shell
bower register pingpp-html5 git://github.com/PingPlusPlus/pingpp-html5
```

之后安装只需运行：

``` shell
bower install pingpp-html5
```
